### PR TITLE
Removed the default config upload

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
 FROM ubuntu:latest
-MAINTAINER "Tim Fall" <tim@midokura.com>
+MAINTAINER Tim Fall <tim@midokura.com>
 
 RUN apt-get update
 RUN apt-get -y install wget openssl openvpn
 
-ADD *.openvpn /etc/openvpn/
+#ADD *.openvpn /etc/openvpn/
 
 ENTRYPOINT ["/usr/sbin/openvpn"]


### PR DESCRIPTION
This should prevent the automated Docker Hub build from erroring out.
